### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ PG_VER=pg15
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 TS_VERSION=main
 PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
-PREV_TS_IMAGE="timescale/timescaledb:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)$(PREV_EXTRA)"
-PREV_IMAGE=$(shell if docker pull $(PREV_TS_IMAGE) >/dev/null; then echo "$(PREV_TS_IMAGE)"; else echo "postgres:$(PG_VER_NUMBER)-alpine"; fi )
+PREV_TS_IMAGE="samagragovernance/postgres:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)$(PREV_EXTRA)"
+PREV_IMAGE=$(shell if docker pull "$(PREV_TS_IMAGE)" >/dev/null 2>&1; then echo "$(PREV_TS_IMAGE)"; else echo "timescale/timescaledb:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)$(PREV_EXTRA)"; fi )
 # Beta releases should not be tagged as latest, so BETA is used to track.
 BETA=$(findstring rc,$(TS_VERSION))
 PLATFORM=linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64


### PR DESCRIPTION
Dockerfile for the project contains below lines:

COPY --from=oldversions /usr/local/lib/postgresql/timescaledb-*.so /usr/local/lib/postgresql/
COPY --from=oldversions /usr/local/share/postgresql/extension/timescaledb--*.sql /usr/local/share/postgresql/extension/

The above lines expects the specified files required to be copied to exist. But the base postgres image don't have any such files due to which it fails.

So, in case we don't have the image at samagragovernance, we should use timescale's image as the base image instead of using postgres image as the base image. 