### PR TITLE
warpsql: Add support for Citus extension

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -52,6 +52,16 @@ jobs:
             fi
             if psql -c "select 1"
             then
+              echo "Test Citus Extension"
+              psql -c "CREATE EXTENSION citus;"
+              psql -c "SELECT * FROM citus_version();"
+
+              echo "Test Citus Distributed Table"
+              psql -c "CREATE TABLE test_distributed_table (id serial primary key, data text);"
+              psql -c "SELECT create_distributed_table('test_distributed_table', 'id');"
+              psql -c "INSERT INTO test_distributed_table (data) VALUES ('test data');"
+              psql -c "SELECT * FROM test_distributed_table;"
+
               break
             fi
             sleep 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,3 +93,38 @@ RUN apk add --no-cache --virtual .build-deps \
                 && ls \
                 && make \
                 && make install
+
+## Adding Citus
+
+# Install Citus dependencies
+RUN apk add --no-cache --virtual .citus-deps \
+    curl \
+    jq
+
+# Install Citus
+ARG CITUS_VERSION="11.2.0"
+RUN set -ex \
+    && apk add --no-cache --virtual .citus-build-deps \
+        gcc \
+        libc-dev \
+        make \
+        curl-dev \
+        lz4-dev \
+        zstd-dev \
+        clang \
+        krb5-dev \
+        icu-dev \
+        libxslt-dev \
+        libxml2-dev \
+        llvm15-dev \
+    && CITUS_DOWNLOAD_URL="https://github.com/citusdata/citus/archive/refs/tags/v${CITUS_VERSION}.tar.gz" \
+    && curl -L -o /tmp/citus.tar.gz "${CITUS_DOWNLOAD_URL}" \
+    && tar -C /tmp -xvf /tmp/citus.tar.gz \
+    && chown -R postgres:postgres /tmp/citus-${CITUS_VERSION} \
+    && cd /tmp/citus-${CITUS_VERSION} \
+    && PATH="/usr/local/pgsql/bin:$PATH" ./configure \
+    && make \
+    && make install \
+    && cd ~ \
+    && rm -rf /tmp/citus.tar.gz /tmp/citus-${CITUS_VERSION} \
+    && apk del .citus-deps .citus-build-deps


### PR DESCRIPTION
1. Update Dockerfile
2. Install Citus dependencies (curl, jq)
3. Add build dependencies for Citus (gcc, libc-dev, make, curl-dev, lz4-dev, libxslt-dev, libxml2-dev)
4. Download and install Citus with specified version
5. Remove build dependencies and cleanup temporary files after Citus installation

Fixes: #3