### PR TITLE
[DOCKER] ADD PG Auto Failover

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -77,6 +77,10 @@ jobs:
               echo "Test pg_repack Extension"
               psql -c "CREATE EXTENSION pg_repack;"
               psql -c "select repack.version(), repack.version_sql();"
+
+              echo "Test pgautofailover Extension"
+              psql -c "CREATE EXTENSION pgautofailover CASCADE;"
+              psql -c "SELECT pgautofailover.formation_settings();"
               break
             fi
             sleep 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex \
     && sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" /usr/local/share/postgresql/postgresql.conf.sample
 
 # Update to shared_preload_libraries
-RUN echo "shared_preload_libraries = 'citus,timescaledb,pg_stat_statements'" >> /usr/local/share/postgresql/postgresql.conf.sample
+RUN echo "shared_preload_libraries = 'citus,timescaledb,pg_stat_statements,pgautofailover'" >> /usr/local/share/postgresql/postgresql.conf.sample
 
 # Adding PG Vector
 
@@ -309,8 +309,6 @@ RUN set -eux \
     && cd /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION} \
     && make \
     && make install \
-    && sed -i "s/\(shared_preload_libraries = '[^']*\)/\1,pgautofailover/"  /usr/local/share/postgresql/postgresql.conf.sample \
-
 # clean 
     && cd / \
     && rm -rf /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION} /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION}.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -282,3 +282,36 @@ RUN set -eux \
     && cd / \
     && rm -rf /tmp/pg_repack-${PG_REPACK_VERSION} /tmp/pg_repack.zip \
     && apk del .pg_repack-build-deps 
+
+# Adding pgautofailover
+ARG PG_AUTO_FAILOVER_VERSION
+RUN set -eux \
+    && apk add --no-cache --virtual .pg_auto_failover-build-deps \
+        make \ 
+        gcc \
+        musl-dev \
+        krb5-dev \ 
+        openssl-dev \
+        clang15 \ 
+        ncurses-dev \
+        linux-headers \
+        zstd-dev \
+        lz4-dev \
+        zlib-dev \
+        libedit-dev \
+        libxml2-utils \
+        libxslt-dev \
+        llvm15 \
+# build pg_auto_failover
+    && wget  -O /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION}.zip "https://github.com/hapostgres/pg_auto_failover/archive/refs/tags/v${PG_AUTO_FAILOVER_VERSION}.zip" \
+    && unzip  /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION}.zip -d /tmp \
+    && ls -alh /tmp \
+    && cd /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION} \
+    && make \
+    && make install \
+    && sed -i "s/\(shared_preload_libraries = '[^']*\)/\1,pgautofailover/"  /usr/local/share/postgresql/postgresql.conf.sample \
+
+# clean 
+    && cd / \
+    && rm -rf /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION} /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION}.zip \
+    && apk del .pg_auto_failover-build-deps

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PG_VER=pg15
 CITUS_VERSION="11.2.0"
 POSTGIS_VERSION=3.3.2
 PG_REPACK_VERSION = 1.4.8
+PG_AUTO_FAILOVER_VERSION = 2.0
 POSTGIS_SHA256=2a6858d1df06de1c5f85a5b780773e92f6ba3a5dc09ac31120ac895242f5a77b
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 TS_VERSION=main
@@ -58,7 +59,7 @@ default: image
 	touch .build_$(TS_VERSION)_$(PG_VER)_oss
 
 .build_$(TS_VERSION)_$(PG_VER): Dockerfile
-	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) --build-arg CITUS_VERSION=$(CITUS_VERSION) --build-arg PG_VER=$(PG_VER) --build-arg PG_REPACK_VERSION=$(PG_REPACK_VERSION) --build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) --build-arg POSTGIS_SHA256=$(POSTGIS_SHA256) $(TAG) .
+	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) --build-arg CITUS_VERSION=$(CITUS_VERSION) --build-arg PG_VER=$(PG_VER) --build-arg PG_REPACK_VERSION=$(PG_REPACK_VERSION) --build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) --build-arg PG_AUTO_FAILOVER_VERSION=$(PG_AUTO_FAILOVER_VERSION) --build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) --build-arg POSTGIS_SHA256=$(POSTGIS_SHA256) $(TAG) .
 	touch .build_$(TS_VERSION)_$(PG_VER)
 
 image: .build_$(TS_VERSION)_$(PG_VER)

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -171,6 +171,41 @@ RUN apt-get update \
         /tmp/*               \
         /var/tmp/* 
 
+# Adding pgautofailover
+ARG PG_AUTO_FAILOVER_VERSION
+RUN apt-get update \
+    && apt-get install -y  unzip \
+        build-essential \
+        liblz4-dev \
+        zlib1g-dev \
+        libedit-dev \
+        libssl-dev \
+        wget \
+# build pg_auto_failover
+    && wget  -O /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION}.zip "https://github.com/hapostgres/pg_auto_failover/archive/refs/tags/v${PG_AUTO_FAILOVER_VERSION}.zip" \
+    && unzip  /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION}.zip -d /tmp \
+    && ls -alh /tmp \
+    && cd /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION} \
+    && make \
+    && make install \
+
+# clean 
+    && cd / \
+    && rm -rf /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION} /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION}.zip \
+    && apt-get autoremove --purge -y \
+        unzip \
+        build-essential \
+        liblz4-dev \
+        zlib1g-dev \
+        libedit-dev \
+        libssl-dev \
+        wget \
+    && apt-get clean -y \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/*               \
+        /var/tmp/* 
+
 # Install zombodb extension
 RUN apt-get update -y -qq --fix-missing \
     && apt-get install -y wget gnupg \

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -188,7 +188,6 @@ RUN apt-get update \
     && cd /tmp/pg_auto_failover-${PG_AUTO_FAILOVER_VERSION} \
     && make \
     && make install \
-
 # clean 
     && cd / \
     && rm -rf /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION} /tmp/pg_auto_failove-${PG_AUTO_FAILOVER_VERSION}.zip \

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -6,8 +6,9 @@ PG_VER=pg15
 CITUS_VERSION="11.2.0"
 POSTGIS_MAJOR=3
 PG_MAJOR=15
-POSTGIS_VERSION=3.3.2+dfsg-1.pgdg110+1
+POSTGIS_VERSION=3.3.3+dfsg-1~exp1.pgdg110+1
 PG_REPACK_VERSION = 1.4.8
+PG_AUTO_FAILOVER_VERSION = 2.0
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 
 TS_VERSION=main
@@ -26,7 +27,7 @@ default: image
 .build_$(TS_VERSION)_$(PG_VER): Dockerfile
 	test -n "$(TS_VERSION)"  # TS_VERSION
 	test -n "$(PREV_TS_VERSION)"  # PREV_TS_VERSION
-	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) --build-arg CITUS_VERSION=$(CITUS_VERSION) --build-arg PG_REPACK_VERSION=$(PG_REPACK_VERSION)  --build-arg POSTGIS_MAJOR=$(POSTGIS_MAJOR) --build-arg PG_MAJOR=$(PG_MAJOR) --build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) $(TAG)  ..
+	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) --build-arg CITUS_VERSION=$(CITUS_VERSION) --build-arg PG_REPACK_VERSION=$(PG_REPACK_VERSION) --build-arg PG_AUTO_FAILOVER_VERSION=$(PG_AUTO_FAILOVER_VERSION)  --build-arg POSTGIS_MAJOR=$(POSTGIS_MAJOR) --build-arg PG_MAJOR=$(PG_MAJOR) --build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) $(TAG)  ..
 	touch .build_$(TS_VERSION)_$(PG_VER)-bitnami
 
 image: .build_$(TS_VERSION)_$(PG_VER)

--- a/bitnami/timescaledb-bitnami-entrypoint.sh
+++ b/bitnami/timescaledb-bitnami-entrypoint.sh
@@ -4,9 +4,9 @@
 # the shared preload list, or else it gets overwritten.
 if [ -z "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]
 then
-    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="citus,timescaledb,zombodb,pg_repack"
+    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="citus,timescaledb,zombodb,pg_repack,pgautofailover"
 else
-    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="citus,timescaledb,zombodb,pg_repack,$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
+    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="citus,timescaledb,zombodb,pg_repack,pgautofailover,$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
 fi
 export POSTGRESQL_SHARED_PRELOAD_LIBRARIES
 


### PR DESCRIPTION
Fixes #8 

1. Installed the required build dependency.
2. Downloaded pgautofailover v2.0 from https://github.com/hapostgres/pg_auto_failoverand built it.
3. Installed pgautofailover.
4. Cleaned up the build dependencies.
5. Updated the smoke test for pgautofailover. 

## Testing
I have test the images locally and have found no issues 