### PR TITLE
warpsql/gh_pages: Add website for documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>WarpSQL</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
+
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+      window.$docsify = {
+        name: 'WarpSQL',
+        repo: 'https://github.com/Samagra-Development/WarpSQL',
+        nameLink: 'https://github.com/Samagra-Development/WarpSQL/releases',
+      }
+  </script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  
+  <!-- docsify-themeable -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/js/docsify-themeable.min.js"></script>
+
+  <!-- Recommended -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/zoom-image.min.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
1. Using docsify to create static website.
2. The website is connected to the repo's `Readme.md` file, so whenever our Readme file gets updated, the website stays in sync.

Steps to run website locally
1. `npm i docsify-cli -g`
2. `docsify serve .`

Fixes: #67 

https://github.com/Samagra-Development/WarpSQL/assets/64846852/5b65dbb9-2de9-49b7-8e26-76a2f5186976


CC: @ChakshuGautam 