### PR TITLE
warpsql/docker-compose: Added pgwatch2 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,13 @@ services:
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
       HASURA_GRAPHQL_MIGRATIONS_DISABLE_TRANSACTION: "true"
       HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
+
+  pgwatch2:
+    image: cybertec/pgwatch2-postgres:latest
+    ports:
+      - "3000:3000"
+    environment:
+      PW2_ADHOC_CONN_STR: "postgresql://timescaledb:postgrespassword@timescaledb:5432/postgres?sslmode=disable"
+    depends_on:
+      - "timescaledb"
+    restart: always


### PR DESCRIPTION
1. Added pgwatch2 service to the Docker Compose file.
2. Configured pgwatch2 to use the cybertec/pgwatch2-postgres:latest image.
3. Exposed port 3000 for the pgwatch2 service.
4. Set up PW2_ADHOC_CONN_STR environment variable for pgwatch2 to connect to the timescaledb service.
5. Configured pgwatch2 to restart automatically in case of failure.
6. Added timescaledb as a dependency for pgwatch2 to ensure timescaledb starts before pgwatch2.

Fixes: #52

CC: @singhalkarun 