### PR TITLE
add concurrency to the workflow

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,4 +1,9 @@
 name: Smoke Test Docker Image
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 on:
   pull_request:
   push:


### PR DESCRIPTION
This PR adds concurrency to the smoke test, ensuring that only the most recent commit of a pull request is tested and prevent job execution on outdated commits.