### PR TITLE
add image analysis to github workflow

### DIFF
--- a/.github/workflows/image-analysis-comment.yml
+++ b/.github/workflows/image-analysis-comment.yml
@@ -1,0 +1,97 @@
+# image-analysis.yml and image-analysis-comment.yml workflows,  are used to calculate and comment the size difference between Dockerfile in the main branch and the changes made in a pull request.
+
+name: comment Image Analysis on PR
+
+# this workflow writes all the messages present in the comment artifact to the respective Pull Request so only one parallel run is required
+concurrency:
+  group: ${{ github.workflow }}
+
+on:
+  workflow_run:
+    workflows: ["Image Analysis"]
+    types:
+      - completed
+
+jobs:
+  comment-on-pr:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Download the comments list
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          workflow: image-analysis.yml
+          name: image-analysis-comments
+          check_artifacts: true
+          search_artifacts: true
+          if_no_artifact_found: fail
+      
+      # set up dependency for github scripts
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: |
+          npm install fs
+
+      - name: Comment on PR
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Modified from https://github.com/kanga333/comment-hider
+            async function hideComment(issueNumber,userName,reason){
+              const comments = await github.issues.listComments({
+                owner:context.repo.owner,
+                repo:context.repo.repo,
+                issue_number: issueNumber
+              });
+              const ids = [];
+              for (const r of comments.data) {
+                if (r.user !== null && r.user.login !== userName) {
+                  continue;
+                }
+                ids.push(r.node_id);
+              }
+              ids.splice(-1,1);
+              for ( let id of ids){
+              const resp = await github.graphql(`
+                  mutation {
+                    minimizeComment(input: {classifier: ${reason}, subjectId: "${id}"}) {
+                      minimizedComment {
+                        isMinimized
+                      }
+                    }
+                  }
+                `);
+              
+                if (resp.errors) {
+                  core.setFailed(`${resp.errors[0].message}`);
+                }
+              }
+            }
+            var fs = require('fs');
+            var comments =  JSON.parse(fs.readFileSync('./comments.json'));
+            console.log(comments);
+            while (comments.length > 0) {
+            const comment = comments[0];   
+            hideComment(comment.issue_number,'github-actions[bot]','OUTDATED') ;        
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: comment.issue_number,
+              body: comment.body
+              });
+              comments.shift(); 
+            }
+
+      - name: Delete the comment list
+        uses: jimschubert/delete-artifacts-action@v1
+        with:
+          log_level: "debug"
+          artifact_name: image-analysis-comments
+          min_bytes: "0"

--- a/.github/workflows/image-analysis.yml
+++ b/.github/workflows/image-analysis.yml
@@ -1,0 +1,112 @@
+# image-analysis.yml and image-analysis-comment.yml workflows,  are used to calculate and comment the size difference between Dockerfiles in the main branch and the changes made in a pull request.
+name: Image Analysis
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_run:
+    workflows: ["Smoke Test Docker Image"]
+    types: [completed]
+
+env:
+  ORG: timescaledev
+  TS_VERSION: main
+  PLATFORM: linux/amd64
+
+jobs:
+  image-analysis:
+    name: PG${{ matrix.pg }}-${{ matrix.type }}-analysis
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write #write permission is need to delete actions 
+    strategy:
+      max-parallel: 1  # Running sequentially to add comments to the comment artifact without overwriting
+      fail-fast: false
+      matrix:
+        pg: [15]
+        type: ["bitnami", "normal"]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Check out the source
+        uses: actions/checkout@v3
+
+      - name: Download image built from the PR
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          workflow: smoke-test.yml
+          name: ${{matrix.type}}-${{ github.event.workflow_run.head_sha  }} 
+          check_artifacts: true
+          search_artifacts: true
+          if_no_artifact_found: fail
+          skip_unpack: true # Docker images are too big to unpack with this action
+      - name: unzip the image artifact 
+        run: |
+          unzip ${{matrix.type}}-${{ github.event.workflow_run.head_sha }}.zip
+
+      - name: Load image into docker
+        run: |
+          cat ./${{matrix.type}}-${{ github.event.workflow_run.head_sha  }}.tar  | docker import - smoketest-image
+      
+      # set up dependency for github scripts
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: |
+          npm install fs
+
+      - name: Download metrics of main branch
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          workflow: image-analysis.yml
+          name: image-metric-${{matrix.type}}
+          check_artifacts: true
+          search_artifacts: true
+          if_no_artifact_found: warn
+
+      - name: Download comments artifact 
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          workflow: image-analysis.yml
+          name: image-analysis-comments
+          check_artifacts: true
+          search_artifacts: true
+          workflow_conclusion: ""  # Consider current successful runs of matrix jobs 
+          if_no_artifact_found: warn
+
+      - name: Analyse image
+        uses: actions/github-script@v6.4.1
+        with:
+          workspace: ${{ github.workspace }}
+          image-type: ${{matrix.type}}
+          script: |
+            const fs = require('fs')
+            const script = require('./image_size.js')
+            console.log(script({github, context, exec,core,fs}))
+
+      - name: Upload the updated comments  
+        uses: actions/upload-artifact@v3
+        if: github.event.workflow_run.event == 'pull_request'
+        with:
+          name: image-analysis-comments
+          path: comments.json
+          if-no-files-found: error
+
+      - name: Upload metrics from main branch
+        uses: actions/upload-artifact@v3
+        if: github.event.workflow_run.event == 'push'
+        with:
+          name: image-metric-${{matrix.type}}
+          path: image-metrics-${{matrix.type}}.json
+          if-no-files-found: error
+
+        
+      - name: Delete docker image artifact
+        uses: jimschubert/delete-artifacts-action@v1
+        with:
+          log_level: "debug"
+          artifact_name: ${{matrix.type}}-${{ github.event.workflow_run.head_sha  }}
+          min_bytes: "0"

--- a/.github/workflows/smoke-test-packer.yml
+++ b/.github/workflows/smoke-test-packer.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   smoketest-all:
-    name: PG${{ matrix.pg }}-${{ matrix.type }}
+    name: PG${{ matrix.pg }}-${{ matrix.type }}-paacker
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -72,7 +72,7 @@ jobs:
           docker logs smoketest-container
   
   smoketest-individual:
-    name: PG${{ matrix.pg }}-${{ matrix.type }}-${{matrix.extention}}
+    name: PG${{ matrix.pg }}-${{ matrix.type }}-${{matrix.extention}}-packer
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,9 +1,9 @@
 name: Smoke Test Docker Image
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 on:
   pull_request:
   push:
@@ -17,14 +17,24 @@ env:
 
 jobs:
   smoketest:
-    name: PG${{ matrix.pg }}-${{ matrix.type }}
+    name: PG${{ matrix.pg }}-${{ matrix.type }}-docker
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         pg: [15]
-        type: ['normal', 'bitnami']
+        type: ["normal", "bitnami"]
     steps:
+      - name: set the correct commit sha
+        env:
+          EVENT: ${{github.event_name}}
+        run: |
+          if [ "$EVENT" == 'pull_request' ]
+          then
+              echo "commit=${{ github.event.pull_request.head.sha}}"  >> "$GITHUB_ENV"
+          else
+              echo "commit=${{ github.sha}}"  >> "$GITHUB_ENV"
+          fi
       - name: Check out the source
         uses: actions/checkout@v3
 
@@ -75,3 +85,21 @@ jobs:
         if: always()
         run: |
           docker logs smoketest-container
+
+      - name: export the image
+        run: |
+          set -eux
+          export PGHOST=localhost
+          export PGUSER=postgres
+          export PGPASSWORD=test1234
+          docker container stop smoketest-container || true
+          docker container rm smoketest-container || true
+          docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=${PGPASSWORD} --name smoketest-container smoketest-image
+          docker export smoketest-container  > ${{matrix.type}}-${{  env.commit  }}.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{matrix.type}}-${{  env.commit  }}
+          path: ./${{matrix.type}}-${{  env.commit  }}.tar
+          retention-days: 1

--- a/image_size.js
+++ b/image_size.js
@@ -1,0 +1,212 @@
+async function saveToFile(metrics, fs, path) {
+  const filePath = path;
+  const jsonData = JSON.stringify(metrics, null, 2);
+
+  try {
+    await fs.promises.writeFile(filePath, jsonData);
+    console.log(`Metrics saved to ${filePath}`);
+  } catch (error) {
+    console.error(`Error saving metrics to ${filePath}: ${error}`);
+  }
+}
+
+async function readFromFile(fs, path) {
+  const filePath = path;
+  try {
+    const jsonData = await fs.promises.readFile(filePath);
+    const metrics = JSON.parse(jsonData);
+    return metrics;
+  } catch (error) {
+    console.error(`Error reading metrics from ${filePath}: ${error}`);
+    return null;
+  }
+}
+
+function parseSizeToBytes(value, unit) {
+  let bytes;
+
+  switch (unit) {
+    case "KB":
+      bytes = value * 1024;
+      break;
+    case "MB":
+      bytes = value * 1024 * 1024;
+      break;
+    case "GB":
+      bytes = value * 1024 * 1024 * 1024;
+      break;
+    default:
+      throw new Error("Invalid size unit");
+  }
+
+  return bytes;
+}
+
+function formatBytes(bytes, decimals = 2) {
+  if (bytes == null) return "Unknown";
+  if (!+bytes) return "0 Bytes";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = [
+    "Bytes",
+    "KiB",
+    "MiB",
+    "GiB",
+    "TiB",
+    "PiB",
+    "EiB",
+    "ZiB",
+    "YiB",
+  ];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}
+
+async function captureExecOutput(
+  exec,
+  command,
+  arguments,
+  ignoreExitCode = false
+) {
+  let myOutput = "";
+  let myError = "";
+
+  const options = {};
+  options.listeners = {
+    stdout: (data) => {
+      myOutput += data.toString();
+    },
+    stderr: (data) => {
+      myError += data.toString();
+    },
+  };
+  if (ignoreExitCode) {
+    options.ignoreReturnCode = true;
+  }
+  await exec.exec(command, arguments, options);
+  console.log(myOutput);
+  return myOutput;
+}
+
+function calculatePercentageChange(currentValue, previousValue) {
+  if (!previousValue || previousValue === 0) {
+    return "";
+  }
+
+  const percentageChange =
+    ((currentValue - previousValue) / previousValue) * 100;
+  const colorIndicator =
+    percentageChange > 0 ? ":small_red_triangle:" : ":small_red_triangle_down:";
+  console.log(percentageChange);
+  console.log(percentageChange.toFixed(2));
+  const formattedChange = `[${percentageChange.toFixed(
+    2
+  )} %  ${colorIndicator}]`;
+  return formattedChange;
+}
+
+function createIssueComment(
+  imageType,
+  commitSHA,
+  imageSizeInBytes,
+  metricToCompare
+) {
+  const currentSize = formatBytes(imageSizeInBytes);
+  const previousSize = formatBytes(metricToCompare?.imageSize || null);
+  const percentageChange = calculatePercentageChange(
+    imageSizeInBytes,
+    metricToCompare?.imageSize || null
+  );
+
+  const githubMessage = `### :bar_chart: ${imageType} Image Analysis  (Commit: ${commitSHA} )
+  #### Summary
+  
+  - **Current Size:** ${currentSize} ${percentageChange}
+  - **Previous Size :** ${previousSize}`;
+
+  return githubMessage;
+}
+
+async function getPullNumber(github, workflow_run, context, core) {
+  let head = `${workflow_run.actor.login}:${workflow_run.head_branch}`;
+  let prNumber = (
+    await github.rest.pulls.list({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      head: head,
+    })
+  ).data[0]?.number;
+  if (prNumber != undefined) {
+    console.log(`Found PR number ${prNumber} based on base and head branches`);
+    core.exportVariable("pull_request_number", prNumber);
+  } else {
+    core.setFailed(
+      `Action failed: Pull-Request Number NOt found with head: ${head}`
+    );
+  }
+
+  console.log(prNumber);
+  return prNumber;
+}
+
+module.exports = async ({ github, context, exec, core, fs }) => {
+  let commitSHA = context.payload.workflow_run.head_sha;
+  let imageSize = await captureExecOutput(exec, "docker", [
+    "image",
+    "list",
+    "--format",
+    "{{.Size}}",
+    "smoketest-image",
+  ]);
+  let imageSizeInBytes = parseSizeToBytes(
+    imageSize.trim().slice(0, -2),
+    imageSize.trim().slice(-2)
+  );
+  let imageLayers = await captureExecOutput(exec, "docker", [
+    "image",
+    "history",
+    "-H",
+    "--format",
+    "table {{.CreatedBy}} \\t\\t {{.Size}}",
+    "smoketest-image",
+  ]);
+  const imageType = core.getInput("image-type", { required: true });
+
+  const workspace = core.getInput("workspace", { required: true });
+
+  if (context.payload.workflow_run.event == "pull_request") {
+    const metricToCompare =
+      (await readFromFile(fs, "image-metrics-" + imageType + ".json")) || {};
+
+    let githubMessage = createIssueComment(
+      imageType,
+      commitSHA,
+      imageSizeInBytes,
+      metricToCompare
+    );
+    let issueNumber = await getPullNumber(
+      github,
+      context.payload.workflow_run,
+      context,
+      core
+    );
+    const comment = {
+      body: githubMessage,
+      issue_number: issueNumber,
+    };
+    const commentQueue = (await readFromFile(fs, "comments.json")) || [];
+    commentQueue.push(comment);
+    console.log(commentQueue);
+    await saveToFile(commentQueue, fs, "comments.json");
+  } else if (context.payload.workflow_run.event == "push") {
+    const updatedMetric = {
+      imageId: imageType,
+      imageSize: imageSizeInBytes,
+    };
+    console.log(updatedMetric);
+    await saveToFile(updatedMetric, fs, "image-metrics-" + imageType + ".json");
+  }
+};


### PR DESCRIPTION
Fixes #42 
This PR add workflows that analyze the size differences in the Docker image. The key features of this PR are:
1. Automatically hides old bot messages.
2. Updates the Docker image's current statistics when commits are posted to the main branch.

The process involves two workflows: image-analysis.yml and image-analysis-comment.yml.

The image-analysis.yml workflow, which lacks write permissions on issues, is responsible for importing the image, conducting the analysis, exporting the details as comments in the pull request, and updating the comparison metrics when a push occurs on the main branch.

On the other hand, the image-analysis-comment.yml workflow writes the comments to their respective issues and hide bot messages from old runs.