### PR TITLE
add limit to parallel jobs in packer testing

### DIFF
--- a/.github/workflows/smoke-test-packer.yml
+++ b/.github/workflows/smoke-test-packer.yml
@@ -76,6 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         pg: [15]
         type: ['alpine', 'bitnami']


### PR DESCRIPTION
This PR limits the Number of checks running in parallel when testing individual extensions, as running all of them at once leads to `429 Too Many Requests` errors
https://github.com/Samagra-Development/WarpSQL/actions/runs/5520523802/jobs/10067268132 