### PR TITLE
update the workflow to build docker images for tag 1.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,9 +41,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
             ref: ${{inputs.version}}
-      - name: patch libssl version 
+      - name: patch libssl and clang version 
         run: |
             sed -i '44s/libssl1.1/libssl3/' Dockerfile
+            sed -i '87s/clang/clang15/' Dockerfile
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,9 @@ on:
         description: 'TS version to be used'
         required: false
         default: main
+      docker_tag:
+        description: 'The version used to tag the Docker image.'
+        required: true
 env:
   ORG: ${{inputs.ORG}}
   TS_VERSION: ${{inputs.ts_version}}
@@ -38,7 +41,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
             ref: ${{inputs.version}}
-
+      - name: patch libssl version 
+        run: |
+            sed -i '44s/libssl1.1/libssl3/' Dockerfile
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -56,13 +61,13 @@ jobs:
 
       - name: Build and push multi-platform Docker image for postgres
         run: |
-            if [${{inputs.tag_latest}} == 'true']; then
+            if ['${{inputs.tag_latest}}' == 'true']; then
               export BETA=''
             fi
             make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }} \
             PREV_TS_VERSION=$TS_VERSION TAG_VERSION="$TAG_VERSION" PREV_EXTRA="${{ matrix.oss }}" BETA=$BETA
         env:
-            TAG_VERSION: "${{inputs.ORG}}/postgres:${{inputs.version}}-pg${{ matrix.pg }}"
+            TAG_VERSION: "${{inputs.ORG}}/postgres:${{inputs.docker_tag}}-pg${{ matrix.pg }}"
   # Build bitnami images of TimscaleDB.
   # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
   # The images are only built for TSL code.
@@ -85,10 +90,10 @@ jobs:
 
       - name: Build and push amd64 Docker image for TimescaleDB bitnami
         run: |
-          if [${{inputs.tag_latest}} == 'true']; then
+          if ['${{inputs.tag_latest}}' == 'true']; then
             export BETA=''
           fi
           make push ORG=$ORG PG_VER=pg${{ matrix.pg }} PREV_TS_VERSION=$TS_VERSION BETA=$BETA TAG_VERSION="$TAG_VERSION"
         working-directory: bitnami
         env:
-          TAG_VERSION: "${{inputs.ORG}}/timescaledb:${{inputs.version}}-pg${{ matrix.pg }}-bitnami"
+          TAG_VERSION: "${{inputs.ORG}}/timescaledb:${{inputs.docker_tag}}-pg${{ matrix.pg }}-bitnami"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -66,7 +66,7 @@ jobs:
               export BETA=''
             fi
             make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }} \
-            PREV_TS_VERSION=$TS_VERSION TAG_VERSION="$TAG_VERSION" PREV_EXTRA="${{ matrix.oss }}" BETA=$BETA
+            PREV_TS_VERSION=$TS_VERSION TS_VERSION=$TS_VERSION TAG_VERSION="$TAG_VERSION" PREV_EXTRA="${{ matrix.oss }}" BETA=$BETA
         env:
             TAG_VERSION: "${{inputs.ORG}}/postgres:${{inputs.docker_tag}}-pg${{ matrix.pg }}"
   # Build bitnami images of TimscaleDB.
@@ -94,7 +94,7 @@ jobs:
           if ['${{inputs.tag_latest}}' == 'true']; then
             export BETA=''
           fi
-          make push ORG=$ORG PG_VER=pg${{ matrix.pg }} PREV_TS_VERSION=$TS_VERSION BETA=$BETA TAG_VERSION="$TAG_VERSION"
+          make push ORG=$ORG PG_VER=pg${{ matrix.pg }} PREV_TS_VERSION=$TS_VERSION TS_VERSION=$TS_VERSION BETA=$BETA TAG_VERSION="$TAG_VERSION"
         working-directory: bitnami
         env:
           TAG_VERSION: "${{inputs.ORG}}/timescaledb:${{inputs.docker_tag}}-pg${{ matrix.pg }}-bitnami"


### PR DESCRIPTION
Fixes #121 
This PR modifies the workflow:
- Adds the `docker_tag` input
- Patches the package version for `clang `and `libssl`

## Test
Tested the changes against the [`1.0`](https://github.com/PiyushRaj927/WarpSQL/releases/tag/1.0) tag in my fork. Action summary available [here](https://github.com/PiyushRaj927/WarpSQL/actions/runs/7569081634).
Docker images can be found [here](https://hub.docker.com/r/d3bug77/postgres/tags).


Inputs given to the workflow
![firefox_01-18-24(16-20-138)](https://github.com/Samagra-Development/WarpSQL/assets/96643110/a8af296b-1711-42d2-acea-3ab3b74dba7d)
