### PR TITLE
Fix PostGIS, citus builds 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN set -ex \
 
 
 # Update to shared_preload_libraries
-RUN echo "shared_preload_libraries = 'timescaledb,pg_cron,citus'" >> /usr/local/share/postgresql/postgresql.conf.sample
+RUN echo "shared_preload_libraries = 'citus,timescaledb,pg_cron'" >> /usr/local/share/postgresql/postgresql.conf.sample
 # Adding PG Vector
 
 RUN cd /tmp
@@ -218,7 +218,7 @@ RUN set -ex \
         curl-dev \
         lz4-dev \
         zstd-dev \
-        clang-15 \
+        clang15 \
         krb5-dev \
         icu-dev \
         libxslt-dev \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PG_VER=pg15
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 TS_VERSION=2.13.0
 PG_CRON_VERSION=v1.6.0
-POSTGIS_VERSION=3.4.1 
+POSTGIS_VERSION=3.4.2 
 CITUS_VERSION=12.1.0
 PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
 PREV_TS_IMAGE="timescale/timescaledb:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)$(PREV_EXTRA)"

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -177,6 +177,7 @@ RUN set -eux \
         g++\
         gcc \
         make \
+        libpcre3-dev \
     && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
     && mkdir -p /usr/src/postgis \
     && tar \
@@ -189,10 +190,11 @@ RUN set -eux \
 # build PostGIS
     \
     && cd /usr/src/postgis \
-    && gettextize \
     && ./autogen.sh \
     && ./configure \
-        --with-pcredir="$(pcre-config --prefix)"  --with-geosconfig="/usr/bin/geos-config"\
+        --with-pcredir="$(pcre-config --prefix)"  \
+        --with-geosconfig="/usr/bin/geos-config" \
+        CFLAGS="-idirafter'/opt/bitnami/postgresql/include'"  # # Prefer latest system headers over Bitnami outdated libraries \
     && make -j$(nproc) \
     && make install \
     && cd / \

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -6,7 +6,7 @@ PG_VER=pg15
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 PG_CRON_VERSION=v1.6.0
 TS_VERSION=2.13.0
-POSTGIS_VERSION=3.4.1 	
+POSTGIS_VERSION=3.4.2 	
 CITUS_VERSION=12.1.0
 PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
 PREV_TS_IMAGE="timescale/timescaledb:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)-bitnami"

--- a/bitnami/timescaledb-bitnami-entrypoint.sh
+++ b/bitnami/timescaledb-bitnami-entrypoint.sh
@@ -4,9 +4,9 @@
 # shared preload list, or else it gets overwritten.
 if [ -z "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]
 then
-    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="timescaledb,pg_cron,citus"
+    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="citus,timescaledb,pg_cron"
 else
-    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="$POSTGRESQL_SHARED_PRELOAD_LIBRARIES,timescaledb,pg_cron,citus"
+    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="citus,timescaledb,pg_cron,$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
 fi
 export POSTGRESQL_SHARED_PRELOAD_LIBRARIES
 


### PR DESCRIPTION
#123 
This PR has the following changes
- utilize system headers for compilation
- patch PostGIS version to 3.4.2
- update citus in shared_preload_libraries as first